### PR TITLE
bin: Better handling of missing "keyword" argument

### DIFF
--- a/bin/search
+++ b/bin/search
@@ -7,6 +7,11 @@ var search = require('..'),
 	netrc = require('node-netrc'),
 	auth = netrc('api.github.com') || {login: process.env.GH_TOKEN};
 
+if (!keyword) {
+	console.error('Error: keyword required.');
+	process.exit(1);
+}
+
 function error() {
 	arguments = ['duo-search'].concat(arguments);
 	console.error.apply(console, arguments);
@@ -27,6 +32,6 @@ try {
 		error(e, status_codes[e.statusCode]);
 		process.exit(1);
 	}
-	
+
 	error(e, 'Are you connected to the internet?');
 }


### PR DESCRIPTION
This patch adds a bit of sanity to the CLI.  When running `duo search` without an additional "keyword", we would get this error:

```
$ bin/search

Error: Got HTTP status 401
    at Request._callback
(/Users/stephenmathieson/repos/github.com/stephenmathieson/duo-search/index.js:20:12)
    at Request.self.callback
(/Users/stephenmathieson/repos/github.com/stephenmathieson/duo-search/node_modules/request/request.js:373:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous>
(/Users/stephenmathieson/repos/github.com/stephenmathieson/duo-search/node_modules/request/request.js:1318:14)
    at Request.emit (events.js:117:20)
    at IncomingMessage.<anonymous>
(/Users/stephenmathieson/repos/github.com/stephenmathieson/duo-search/node_modules/request/request.js:1266:12)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:943:16
    at process._tickCallback (node.js:419:13)
```

With this commit, we now see:

```
$ bin/search
Error: keyword required.
```
